### PR TITLE
Allow user to select reduced field of view.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Parameters
 
     Transformation along z-axis 
 
-* `~reduced_fov (int, default: 0)`
+* `~field_of_view (int, default: 270)`
 
-    Reduces the field of view to 180 degrees. 
+    The field of view to publish. The maximum view angle is 270 degrees, setting this to a value lower than 270 will remove the left and right sides of the field of view. 
 
 * `~devicename (String, default: "/dev/sick300")`
 

--- a/include/sicks300.h
+++ b/include/sicks300.h
@@ -83,8 +83,10 @@ protected:
   tf::TransformBroadcaster tf_broadcaster_;
   tf::Vector3 transform_vector_;
 
-  //! Sets the field of view to 180 degree
-  bool reduced_FOV_;
+  //! Scan field of view parameters
+  int field_of_view_;
+  int start_scan_;
+  int end_scan_;
 
   //! Send Transform or not
   bool send_transform_;

--- a/src/sicks300.cpp
+++ b/src/sicks300.cpp
@@ -71,42 +71,29 @@ SickS300::SickS300()
 
   transform_vector_ = tf::Vector3(x, y, z);
 
-  // Setting full field of view (270 degree) or reduced (180 degree)
-  param_node.param(std::string("reduced_fov"), param, 0);
-  if (param != 0)
-  {
-    reduced_FOV_ = true;
-    ROS_INFO("INFO: Starting Sick300-Laser with reduced field ov view of 180 degree");
-  }
-  else
-  {
-    reduced_FOV_ = false;
-  }
 
-  if (!reduced_FOV_)
-  {
-    scan_data_.angle_min = -135.f / 180.f * M_PI;
-    scan_data_.angle_max = 135.f / 180.f * M_PI;
-    scan_data_.angle_increment = 0.5f / 180.f * M_PI;
-    scan_data_.time_increment = 0;
-    scan_data_.scan_time = 0.08;
-    scan_data_.range_min = 0.1;
-    scan_data_.range_max = 29.0;
-    scan_data_.ranges.resize(541);
-    scan_data_.intensities.resize(541);
+  // Reduce field of view to this number of degrees
+  double fov;
+  param_node.param(std::string("field_of_view"), fov, 270.0);
+  if ((fov > 270) || (fov < 0)) {
+    ROS_WARN("S300 field of view parameter set out of range (0-270). Assuming 270.");
+    fov = 270.0;
   }
-  else
-  {
-    scan_data_.angle_min = -90.f / 180.f * M_PI;
-    scan_data_.angle_max = 90.f / 180.f * M_PI;
-    scan_data_.angle_increment = 0.5f / 180.f * M_PI;
-    scan_data_.time_increment = 0;
-    scan_data_.scan_time = 0.08;
-    scan_data_.range_min = 0.1;
-    scan_data_.range_max = 29.0;
-    scan_data_.ranges.resize(361);
-    scan_data_.intensities.resize(361);
-  }
+  field_of_view_ = (int)(fov*2.0); // angle increment is .5 degrees
+  field_of_view_ <<=1; field_of_view_ >>=1; // round to a multiple of two
+  start_scan_ = 270 - field_of_view_/2;
+  end_scan_ = 270 + field_of_view_/2;
+
+  scan_data_.angle_min = -(field_of_view_/4.0) / 180.f * M_PI;
+  scan_data_.angle_max = (field_of_view_/4.0) / 180.f * M_PI;
+  scan_data_.angle_increment = 0.5f / 180.f * M_PI;
+  scan_data_.time_increment = 0;
+  scan_data_.scan_time = 0.08;
+  scan_data_.range_min = 0.1;
+  scan_data_.range_max = 29.0;
+  scan_data_.ranges.resize(field_of_view_);
+  scan_data_.intensities.resize(field_of_view_);
+
 
   // Reading device parameters
   param_node.param(std::string("devicename"), device_name_, std::string("/dev/sick300"));
@@ -135,17 +122,10 @@ void SickS300::update()
 
     float* ranges = serial_comm_.getRanges();
     unsigned int numRanges = serial_comm_.getNumRanges();
-    if (!reduced_FOV_)
-    {
-      scan_data_.ranges.resize(numRanges);
-      for (unsigned int i = 0; i < numRanges; i++)
-        scan_data_.ranges[i] = ranges[i];
-    }
-    else
-    {
-      for (unsigned int i = 0; i < 361; i++)
-        scan_data_.ranges[i] = ranges[i + 89];
-    }
+
+    for (unsigned int i = start_scan_, j=0; i < end_scan_; i++, j++)
+      scan_data_.ranges[j] = ranges[i];
+
     scan_data_.header.stamp = ros::Time::now();
 
     scan_data_publisher_.publish(scan_data_);


### PR DESCRIPTION
This replaces the bool 'reduced_fov' parameter with double 'field_of_view'. This allows the user to select what angle of view the laser should publish. Setting this to 180 will have the same effect as setting reduced_fov to 1 previously. Setting it to 260 will remove 5 degrees from the start and end of the scan.
