### PR TITLE
Avoid serial port open command from hanging

### DIFF
--- a/src/serialcomm_s300.cpp
+++ b/src/serialcomm_s300.cpp
@@ -105,7 +105,7 @@ void SerialCommS300::setFlags() {
 
   term.c_cc[VMIN] = 0;
   term.c_cc[VTIME] = 5;
-  term.c_cflag = CS8 | CREAD;
+  term.c_cflag = CS8 | CREAD | HUPCL | CLOCAL;
   term.c_iflag = INPCK;
   term.c_oflag = 0;
   term.c_lflag = 0;


### PR DESCRIPTION
I recently switched from a usb2serial ftdi interface to directly connecting the sick s300 via a rs432 connection. I realized that the serial port command hangs the second time I try to connect to the serial port. The only way I can connect to the laser now is after a reboot.

Setting these termios flags solves this problem. I found this solution by referring to
https://github.com/neobotix/neo_driver/blob/indigo_dev/cob_sick_s300/common/src/SerialIO.cpp#L193